### PR TITLE
Remove inactive 3rd argument in PHP_SETUP_OPENSSL

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -79,15 +79,8 @@ AC_DEFUN([PHP_IMAP_SSL_CHK], [
     if test "$PHP_OPENSSL" = ""; then
       PHP_OPENSSL='no'
     fi
-    PHP_SETUP_OPENSSL(IMAP_SHARED_LIBADD,
-    [
-      AC_DEFINE(HAVE_IMAP_SSL,1,[ ])
-    ], [
-      AC_MSG_ERROR([OpenSSL libraries not found.
-
-      Check whether openssl is on your PKG_CONFIG_PATH and the output in config.log)
-      ])
-    ])
+    PHP_SETUP_OPENSSL([IMAP_SHARED_LIBADD],
+      [AC_DEFINE([HAVE_IMAP_SSL], [1], [ ])])
   elif test -f "$IMAP_INC_DIR/linkage.c"; then
     AC_EGREP_HEADER(ssl_onceonlyinit, $IMAP_INC_DIR/linkage.c, [
       AC_MSG_ERROR([This c-client library is built with SSL support.


### PR DESCRIPTION
The upstream PHP_SETUP_OPENSSL has 3rd argument inactive. If OpenSSL is not found using pkg-config, it always errors out by default. Fix has been addressed in PHP-8.4-dev upstream by removing the 3rd argument:
https://github.com/php/php-src/pull/14323